### PR TITLE
PR to add individual-level data cfr case study for ebola-like disease

### DIFF
--- a/R/cfr_ci.R
+++ b/R/cfr_ci.R
@@ -1,0 +1,15 @@
+# Function to estimate mean CFR with 95% CI from a numeric vector
+cfr_ci <- function(x) {
+  mean <- mean(x)
+  sd <- sd(x)
+  sem <- sd/ sqrt(length(x))
+  margin_of_error <- sem * 1.96
+  lower <- round(mean - margin_of_error, 2)
+  upper <- round(mean + margin_of_error, 2)
+  result <- list(
+    mean = round(mean, 2),
+    lower_ci = lower,
+    upper_ci = upper
+  )
+  return(result)
+}

--- a/R/convert_to_incidence.R
+++ b/R/convert_to_incidence.R
@@ -1,0 +1,17 @@
+# Function to convert to incidence
+convert_to_incidence <- function(sim) {
+  incidence_data <- incidence2::incidence(sim,
+                                          date_index = c("date_onset", "date_death", "date_recovery"),
+                                          interval = 1L) %>%
+    complete_dates() %>%
+    pivot_wider(names_from = count_variable, values_from = count)
+  #Vector with names for renaming
+  rename_vec <- c("date_index" = "date", "date_onset" = "cases", "date_death" = "deaths" , "date_recovery" = "recovered")
+  # Rename columns conditionally
+  for (old_name in names(rename_vec)) {
+    if (old_name %in% colnames(incidence_data)) {
+      colnames(incidence_data)[colnames(incidence_data) == old_name] <- rename_vec[[old_name]]
+    }
+  }
+  return(incidence_data)
+}

--- a/R/estimate_cfr.R
+++ b/R/estimate_cfr.R
@@ -1,0 +1,8 @@
+# Function to calculate cfr by specifying columns from a dataframe with
+# deaths and cases
+estimate_cfr <- function(df, numerator, denominator) {
+  total_deaths <- sum(df[[numerator]])
+  total_cases <- sum(df[[denominator]])
+  cfr <- total_deaths/total_cases*100
+  return(cfr)
+}

--- a/R/id_outbreak_peak.R
+++ b/R/id_outbreak_peak.R
@@ -1,0 +1,14 @@
+# Function to estimate the peak of the outbreak using incidence2
+# Incidence object from linelist has 3 count_variables, but we want the column
+# date_onset only to be considered to estimate the peak
+id_outbreak_peak <- function(linelist) {
+  inc_data <- linelist %>%
+    incidence2::incidence(date_index = "date_onset", interval = 1L) %>%
+    complete_dates()
+  peak <- inc_data %>%
+    estimate_peak(first_only = TRUE) %>%
+    pull(observed_peak) %>%
+    as.character()
+  return(peak)
+
+}

--- a/R/id_outbreak_phases_new.R
+++ b/R/id_outbreak_phases_new.R
@@ -1,0 +1,25 @@
+# Function that takes the outbreak's peak (identified previously by id_outbreak_peak),
+# pastes this on a new column
+
+id_outbreak_phases_new <- function(inc_data, outbreak_peaks){
+  inc_data$date <- as.Date(inc_data$date)
+  # Id start date
+  start_date <- min(inc_data$date)
+  # Select a possible date for the growing phase
+  possible_growing_dates <- inc_data %>%
+    filter(date > start_date + 10 & date < outbreak_peaks) %>%
+    pull(date)
+  # Select one of these dates at random
+  growing_date <- sample(possible_growing_dates, 1)
+  # Add new column with outbreak dates
+  inc_data <- inc_data %>%
+    mutate(outbreak_dates = case_when(
+      date == outbreak_peaks & !duplicated(date) ~ "peak",
+      cases >= 5 & row_number() == min(which(cases >= 5))  ~ "start",
+      date == max(date) & !duplicated(date) ~ "end",
+      date == growing_date ~ "growing",
+      TRUE ~ NA_character_
+    )
+    )
+  return(inc_data)
+}

--- a/R/id_outbreak_phases_old.R
+++ b/R/id_outbreak_phases_old.R
@@ -1,0 +1,18 @@
+#Function to smooth outbreak trend and create a column that indicates the outbreak's
+# peak (mean of window with highest no. of cases), start, and end
+id_outbreak_phases_old <- function(inc_data) {
+  # setting window size
+  window_size <- 7
+  trend <- inc_data %>%
+    mutate(cases_ma = rollmean(cases, k = window_size, fill = NA, align = "center")) %>%
+    mutate(date = as.Date(date)) %>%
+    mutate(cases_ma = replace_na(cases_ma, 0)) %>%
+    mutate(outbreak_dates = case_when(
+      row_number() == which.max(cases_ma) ~ "peak",
+      row_number() == which.min(if_else(cases_ma > 1, row_number(), Inf)) ~ "start",
+      date == max(date) ~ "end",
+      TRUE ~ NA_character_
+    ))
+}
+
+

--- a/R/run_ebola_simulations.R
+++ b/R/run_ebola_simulations.R
@@ -1,0 +1,25 @@
+# Function to run multiple instances of sim_linelist
+run_ebola_simulations <- function(sim_count) {
+  # Initialize empty list to store simulation results
+  results <- vector("list", length = sim_count)
+
+  # Loop through simulations
+  for (i in 1:sim_count) {
+    # Set seed for reproducibility
+    set.seed(i)  # Use loop counter for unique seeds
+
+    # Run the simulation code and store the result
+    results[[i]] <- sim_linelist(
+      contact_distribution = contact_distribution,
+      infect_period = ip_ebola_epidist,
+      onset_to_hosp = NA,
+      onset_to_death = o_d_ebola_epidist,
+      onset_to_recovery = o_r_ebola_epidist,
+      prob_infect = 0.7,
+      outbreak_size = c(500, 2000),
+      non_hosp_death_risk = 0.3
+    )
+  }
+  # Return the list of simulation results
+  return(results)
+}

--- a/R/run_ebola_simulations.R
+++ b/R/run_ebola_simulations.R
@@ -11,8 +11,10 @@ run_ebola_simulations <- function(sim_count) {
     # Run the simulation code and store the result
     results[[i]] <- sim_linelist(
       contact_distribution = contact_distribution,
-      infect_period = ip_ebola_epidist,
+      infectious_period = ip_ebola_epidist,
       onset_to_hosp = NA,
+      hosp_risk = NA,
+      hosp_death_risk = NA,
       onset_to_death = o_d_ebola_epidist,
       onset_to_recovery = o_r_ebola_epidist,
       prob_infect = 0.7,

--- a/R/subset_outbreak_phase.R
+++ b/R/subset_outbreak_phase.R
@@ -1,0 +1,14 @@
+# Function to select a random date within an outbreak phase and create a subset
+# of data between relevant dates of the outbreak
+subset_outbreak_phase <- function(data, from, to) {
+  # Sample a random date between "from" and "to" statuses
+  sampled_date <- data %>%
+    slice(sample(seq(which(outbreak_dates == from), which(outbreak_dates == to)), 1)) %>%
+    pull(date) %>%
+    as.character()
+
+  # Subset data based on the sampled date
+  subset_data <- data[data$date <= sampled_date, ]
+
+  return(subset_data)
+}

--- a/R/tidy_sim_results.R
+++ b/R/tidy_sim_results.R
@@ -1,0 +1,16 @@
+# Function to process simulation results
+tidy_sim_results <- function(sim_data) {
+  # Converting class to character so that it's possible to use ifelse
+  sim_data$date_outcome <- as.character(sim_data$date_outcome)
+  # Loop through each individual and update columns
+  for (i in 1:nrow(sim_data)) {
+    sim_data$date_death[i] <- ifelse(sim_data$outcome[i] == "died", sim_data$date_outcome[i], NA)
+    sim_data$date_recovery[i] <- ifelse(sim_data$outcome[i] == "recovered", sim_data$date_outcome[i], NA)
+  }
+  # Convert date columns to Date class
+  sim_data$date_death <- as.Date(sim_data$date_death, format = "%Y-%m-%d")
+  sim_data$date_recovery <- as.Date(sim_data$date_recovery, format = "%Y-%m-%d")
+
+  return(sim_data)
+}
+

--- a/analyses/Linelist_cs_ebola_simulations.R
+++ b/analyses/Linelist_cs_ebola_simulations.R
@@ -82,6 +82,7 @@ rt_ebola_growing <- lapply(incidence_ebola_trend, subset_outbreak_phase, from = 
 rt_ebola_decline <- lapply(incidence_ebola_trend, subset_outbreak_phase, from = "peak", to = "end")
 
 # 3rd list of dfs, with the cut-off point at the peak of the outbreak
+# Ideally this would be done with subset_outbreak_phase as well
 rt_ebola_peak <- incidence_ebola_trend
 for (i in seq_along(rt_ebola_peak)) {
   peak_index <- which(rt_ebola_peak[[i]]$outbreak_dates == "peak")

--- a/analyses/Linelist_cs_ebola_simulations.R
+++ b/analyses/Linelist_cs_ebola_simulations.R
@@ -1,0 +1,277 @@
+
+# Script for individual-level data case study 4: disease with a delay from onset
+# to death shorter than onset to recovery (Ebola-like outbreak).
+# Methods to compare:
+# 1) Naive estimate of deaths/cases
+# 2) Retrospective cohort by omitting latest cases for which we don't expect to have an outcome (i.e., within 1 onset-death before real-time)
+# 3) Using {cfr} function estimate_outcomes to recalculate denominator
+# 4) Using {cfr} function cfr_static
+
+
+# Using simulist to simulate outbreak data
+# Columns that we need: onset date, column to indicate outcome, outcome date (recovery/death)
+
+library(data.table)
+library(zoo)
+library(tidyverse)
+library(simulist)
+library(epiparameter)
+library(incidence2)
+library(kableExtra)
+
+contact_distribution <- epidist(
+  disease = "ebola",
+  epi_dist = "contact distribution",
+  prob_distribution = "pois",
+  prob_distribution_params = c(mean = 3)
+)
+
+ebola_ip_meansd <- c(mean = 9.4, sd = 5.5)
+# From https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4560911/
+
+ebola_ip_params <- convert_summary_stats_to_params("lnorm", mean = ebola_ip_meansd[["mean"]], sd = ebola_ip_meansd[["sd"]])
+
+ip_ebola_epidist <- epidist(
+  disease = "ebola",
+  epi_dist = "infectious_period",
+  prob_distribution = "lnorm",
+  prob_distribution_params = c(meanlog = ebola_ip_params$meanlog, sdlog = ebola_ip_params$sdlog),
+  auto_calc_params = TRUE
+)
+
+# No distributions in epireview
+# summary statistics: mean = 18 and sd = 4
+
+onset_recovery_ebola <- convert_summary_stats_to_params("gamma", mean = 18, sd = 4)
+
+o_r_ebola_epidist <- epidist(
+  disease = "ebola",
+  epi_dist = "onset to recovery",
+  prob_distribution = "gamma",
+  prob_distribution_params = c(shape = onset_recovery_ebola[["shape"]], scale = onset_recovery_ebola[["scale"]])
+)
+
+o_d_ebola_epidist <- epidist_db(
+  disease = "ebola",
+  epi_dist = "onset to death",
+  single_epidist = TRUE
+)
+
+# Function rum_ebola_simulations uses simulist to create a list with n=100 (for now) linelists
+set.seed(487593478)
+simulations_ebola <- run_ebola_simulations(100)
+
+# Function tidy_sim_results creates 2 new columns (date_onset and date_recovery) and makes sure they're on a date format
+linelist_with_added_columns <- lapply(simulations_ebola, tidy_sim_results)
+
+
+# Function convert_to_incidence uses incidence2 to obtain daily incidence data and modify format so it matches {cfr} requirements
+incidence_ebola <- lapply(linelist_with_added_columns, convert_to_incidence)
+
+
+# Identifying outbreak peak
+outbreak_peaks <- sapply(linelist_with_added_columns, id_outbreak_peak)
+
+# Function id_outbreak_phases to establish the trend of the outbreak and identify the start, peak, and end-points
+
+incidence_ebola_trend <- Map(id_outbreak_phases_new, incidence_ebola, outbreak_peaks)
+
+# Function subset_outbreak_phase to create 2 lists of dfs, one with a random cut-off point in the growing phase,
+# and another one with a random cut-off point in the declining phase of the outbreak
+rt_ebola_growing <- lapply(incidence_ebola_trend, subset_outbreak_phase, from = "start", to = "peak")
+rt_ebola_decline <- lapply(incidence_ebola_trend, subset_outbreak_phase, from = "peak", to = "end")
+
+# 3rd list of dfs, with the cut-off point at the peak of the outbreak
+rt_ebola_peak <- incidence_ebola_trend
+for (i in seq_along(rt_ebola_peak)) {
+  peak_index <- which(rt_ebola_peak[[i]]$outbreak_dates == "peak")
+  rt_ebola_peak[[i]] <- rt_ebola_peak[[i]][1:peak_index, ]
+}
+
+# True CFR at the end of the outbreak:
+
+true_cfrs <- sapply(incidence_ebola, estimate_cfr, numerator = "deaths", denominator = "cases")
+true_cfr_ci <- cfr_ci(true_cfrs)
+
+### Naive CFRs
+# Growing phase
+naive_cfr_growing <- sapply(rt_ebola_growing, estimate_cfr, numerator = "deaths", denominator = "cases")
+naive_cfr_growing_ci <- cfr_ci(naive_cfr_growing)
+
+# Peak
+naive_cfr_peak <- sapply(rt_ebola_peak, estimate_cfr, numerator = "deaths", denominator = "cases")
+naive_cfr_peak_ci <- cfr_ci(naive_cfr_peak)
+
+# Decline
+naive_cfr_decline <- sapply(rt_ebola_decline, estimate_cfr, numerator = "deaths", denominator = "cases")
+naive_cfr_decline_ci <- cfr_ci(naive_cfr_decline)
+
+### Retrospective cohort
+# Substitute the column "cases" by 0 if the column "date" is within 8 days of the last/maximum date
+
+# Growing phase
+# Here taking the growing phase cutoff as a random date between the row that says
+# "growing", which is at least 1 o-d away from the start of the outbreak, to
+# "peak"- "start" cannot be used since there needs to be enough deaths/cases
+# to create a retrospective cohort
+
+rt_ebola_growing_cohort <- lapply(incidence_ebola_trend, subset_outbreak_phase, from = "growing", to = "peak")
+
+for (i in seq_along(rt_ebola_growing_cohort)) {
+  df <- rt_ebola_growing_cohort[[i]]
+  df$cases <- ifelse(max(df$date)-df$date <= 8, 0, df$cases)
+  rt_ebola_growing_cohort[[i]] <- df
+}
+
+rc_growing_cfr <- sapply(rt_ebola_growing_cohort, estimate_cfr, numerator = "deaths", denominator = "cases")
+rc_growing_cfr_ci <- cfr_ci(rc_growing_cfr)
+
+
+# Peak
+
+rt_ebola_peak_cohort <- rt_ebola_peak
+
+for (i in seq_along(rt_ebola_peak_cohort)) {
+  df <- rt_ebola_peak_cohort[[i]]
+  df$cases <- ifelse(max(df$date)-df$date <= 8, 0, df$cases)
+  rt_ebola_peak_cohort[[i]] <- df
+}
+
+rc_peak_cfr <- sapply(rt_ebola_peak_cohort, estimate_cfr, numerator = "deaths", denominator = "cases")
+rc_peak_ci <- cfr_ci(rc_peak_cfr)
+
+
+# Decline
+
+rt_ebola_decline_cohort <- rt_ebola_decline
+
+for (i in seq_along(rt_ebola_decline_cohort)) {
+  df <- rt_ebola_decline_cohort[[i]]
+  df$cases <- ifelse(max(df$date)-df$date <= 8, 0, df$cases)
+  rt_ebola_decline_cohort[[i]] <- df
+}
+
+rc_decline_cfr <- sapply(rt_ebola_decline_cohort, estimate_cfr, numerator = "deaths", denominator = "cases")
+rc_decline_ci <- cfr_ci(rc_decline_cfr)
+
+## Delay-adjusted ratio
+# Getting onset-death delay from {epiparameter}
+
+o_d_ebola_epidist_extracted <- epidist_db(
+  disease = "ebola",
+  epi_dist = "onset to death",
+  author = "The Ebola Outbreak Epidemiology Team"
+)
+o_d_ebola_params <- get_parameters(o_d_ebola_epidist_extracted)
+
+# Growing phase- here we can take any date from the beginning of the outbreak to the peak
+# because the delay-adjusted method can be used with any no. deaths, even when there
+# haven't been any deaths yet
+
+known_outcomes_growing <- lapply(rt_ebola_growing, cfr::estimate_outcomes, function(x) dgamma(x, shape = o_d_ebola_params[["shape"]], scale = o_d_ebola_params[["scale"]]))
+cfr_delay_growing <- sapply(known_outcomes_growing, estimate_cfr, numerator = "deaths", denominator = "estimated_outcomes")
+cfr_delay_growing_ci <- cfr_ci(cfr_delay_growing)
+
+# Peak
+
+known_outcomes_peak <- lapply(rt_ebola_peak, cfr::estimate_outcomes, function(x) dgamma(x, shape = o_d_ebola_params[["shape"]], scale = o_d_ebola_params[["scale"]]))
+cfr_delay_peak <- sapply(known_outcomes_peak, estimate_cfr, numerator = "deaths", denominator = "estimated_outcomes")
+cfr_delay_peak_ci <- cfr_ci(cfr_delay_peak)
+
+# Decline
+
+known_outcomes_decline <- lapply(rt_ebola_decline, cfr::estimate_outcomes, function(x) dgamma(x, shape = o_d_ebola_params[["shape"]], scale = o_d_ebola_params[["scale"]]))
+cfr_delay_decline <- sapply(known_outcomes_decline, estimate_cfr, numerator = "deaths", denominator = "estimated_outcomes")
+cfr_delay_decline_ci <- cfr_ci(cfr_delay_decline)
+
+
+## Using {cfr_static}
+
+# Growing
+
+cfr_cfr_growing <- unlist(sapply(rt_ebola_growing, function(x) {
+  result <- cfr::cfr_static(x, function(x) dgamma(x, shape = o_d_ebola_params[["shape"]], scale = o_d_ebola_params[["scale"]]))
+  result[, 1] * 100  # Extracting only the first column that contains the mean cfr
+}))
+
+cfr_cfr_growing_ci <- cfr_ci(cfr_cfr_growing)
+
+# Peak
+
+cfr_cfr_peak <- unlist(sapply(rt_ebola_peak, function(x) {
+  result <- cfr::cfr_static(x, function(x) dgamma(x, shape = o_d_ebola_params[["shape"]], scale = o_d_ebola_params[["scale"]]))
+  result[, 1] * 100  # Extracting only the first column that contains the mean cfr
+}))
+
+cfr_cfr_peak_ci <- cfr_ci(cfr_cfr_peak)
+
+# Decline
+
+cfr_cfr_decline <- unlist(sapply(rt_ebola_decline, function(x) {
+  result <- cfr::cfr_static(x, function(x) dgamma(x, shape = o_d_ebola_params[["shape"]], scale = o_d_ebola_params[["scale"]]))
+  result[, 1] * 100  # Extracting only the first column that contains the mean cfr
+}))
+
+cfr_cfr_decline_ci <- cfr_ci(cfr_cfr_decline)
+
+
+
+# Making table
+
+table_cs_4 <- data.frame(
+  Method = c("Naive estimate", "Retrospective cohort", "Delay-adjusted ratio", "Using {cfr}", "True CFR"),
+  Growing = c(naive_cfr_growing_ci$mean, rc_growing_cfr_ci$mean, cfr_delay_growing_ci$mean, cfr_cfr_growing_ci$mean, true_cfr_ci$mean),
+  `95% CI` = c(
+    paste(naive_cfr_growing_ci$lower_ci, naive_cfr_growing_ci$upper_ci, sep = ", "),
+    paste(rc_growing_cfr_ci$lower_ci, rc_growing_cfr_ci$upper_ci, sep = ", "),
+    paste(cfr_delay_growing_ci$lower_ci, cfr_delay_growing_ci$upper_ci, sep = ", "),
+    paste(cfr_cfr_growing_ci$lower_ci, cfr_cfr_growing_ci$upper_ci, sep = ", "),
+    paste(true_cfr_ci$lower_ci, true_cfr_ci$upper_ci, sep = ", ")),
+  Peak = c(naive_cfr_peak_ci$mean, rc_peak_ci$mean, cfr_delay_peak_ci$mean, cfr_cfr_peak_ci$mean, true_cfr_ci$mean),
+  `95% CI (Peak)` = c(
+    paste(naive_cfr_peak_ci$lower_ci, naive_cfr_peak_ci$upper_ci, sep = ", "),
+    paste(rc_peak_ci$lower_ci, rc_peak_ci$upper_ci, sep = ", "),
+    paste(cfr_delay_peak_ci$lower_ci, cfr_delay_peak_ci$upper_ci, sep = ", "),
+    paste(cfr_cfr_peak_ci$lower_ci, cfr_cfr_peak_ci$upper_ci, sep = ", "),
+    paste(true_cfr_ci$lower_ci, true_cfr_ci$upper_ci, sep = ", ")
+  ),
+  Declining = c(naive_cfr_decline_ci$mean, rc_decline_ci$mean, cfr_delay_decline_ci$mean, cfr_cfr_decline_ci$mean, true_cfr_ci$mean),
+  `95% CI (Declining)` = c(
+    paste(naive_cfr_decline_ci$lower_ci, naive_cfr_decline_ci$upper_ci, sep = ", "),
+    paste(rc_decline_ci$lower_ci, rc_decline_ci$upper_ci, sep = ", "),
+    paste(cfr_delay_decline_ci$lower_ci, cfr_delay_decline_ci$upper_ci, sep = ", "),
+    paste(cfr_cfr_decline_ci$lower_ci, cfr_cfr_decline_ci$upper_ci, sep = ", "),
+    paste(true_cfr_ci$lower_ci, true_cfr_ci$upper_ci, sep = ", ")
+  )
+  )
+
+
+color_func <- function(value, threshold) {
+  if (abs(value - threshold) <= 0.001) {
+    "white"
+  } else if (abs(value - threshold) <= 2) {
+    "lightgreen"
+  } else if (value < threshold) {
+    "lightblue"
+  } else if (value > threshold) {
+    "lightcoral"
+  }
+}
+
+cols_to_color <- c("Growing", "Peak", "Declining")
+
+cfr_table_colours <- table_cs_4
+for (col in cols_to_color) {
+  cfr_table_colours[[col]] <- sapply(cfr_table_colours[[col]], function(x) {
+    paste0("<span style='background-color:", color_func(x, true_cfr_ci$mean), "; display: block;'>", x, "</span>")
+  })
+}
+
+# Print the data frame with coloured cells
+kable(cfr_table_colours, format = "html", escape = FALSE, col.names = c("Method", "Growing phase CFR mean", "95% CI", "Peak CFR mean", "95% CI", "Decline phase CFR mean", "95% CI")) %>%
+  kable_styling(full_width = FALSE) %>%
+  row_spec(5, bold = TRUE)
+
+
+
+


### PR DESCRIPTION
Steps included

1.	Define parameters for simulist, that include a realistic onset-death delay and a longer onset-recovery
2.	Function run_ebola_simulations that uses simulist to create a list with n=100 (for now) linelists
3.	Function tidy_sim_results, that creates 2 new columns (date_onset and date_recovery) and makes sure they're on a date format
4.	Function convert_to_incidence to use incidence2 and have a list of df with daily aggregated data, pivots the tables so they can be used with cfr, and makes sure the names of the columns are correct
5.	 Function id_outbreak_peak to create a vector that contains all peak dates for every df  using incidence2::estimate_peak
6. Function id_outbreak_phases_new- 4 key outbreak dates
•	Start- first date with > 5 cases
•	Peak- using vector from id_outbreak_peak
•	Growing- date between the start and the peak with sufficient cases and deaths for cfr calculation
•	End-max date
7.	4 different lists of dfs are created
a.	Real time outbreak during growing phase (1) and during declining phase (2): using function subset_outbreak_phase, which takes a random date between start and peak for 1, and between peak and end for 2, and uses this date as a cut-off point for the real-time analysis.
b.	Real-time outbreak at the peak (3): using a for loop to cut the df at the row that says "peak"
c.	(4) For the retrospective-cohort approach, the real-time cut-off is between the "growing" date and the peak date, to ensure there will be enough cases so that the cfr calculation makes sense (i.e., no 0 deaths/cases or deaths/0 cases)
8.	Function estimate_cfr which takes specified columns from data frame to sum(deaths)/sum(cases) and creates a vector with the cfr per dataframe
9.	Function cfr_ci to take cfr numeric vector and estimate mean + 95% CI
